### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/knutwalker/roa/compare/v0.1.1...v0.1.2) - 2024-01-09
+
+### Other
+- Set correct cateogry slugs
+- release ([#1](https://github.com/knutwalker/roa/pull/1))
+- Use value directly in print macro
+- Set rust-version to the current stable version
+- Release
+- Move json output to a global option
+- Create api key with Bearer when first reading it
+- Init
+
 ## [0.1.1](https://github.com/knutwalker/roa/compare/v0.1.0...v0.1.1) - 2024-01-09
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,7 +545,7 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "mataroa-cli"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mataroa-cli"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 repository = "https://github.com/knutwalker/roa"
 authors = ["Paul Horn <developer@knutwalker.de>"]


### PR DESCRIPTION
## 🤖 New release
* `mataroa-cli`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/knutwalker/roa/compare/v0.1.1...v0.1.2) - 2024-01-09

### Other
- Set correct cateogry slugs
- release ([#1](https://github.com/knutwalker/roa/pull/1))
- Use value directly in print macro
- Set rust-version to the current stable version
- Release
- Move json output to a global option
- Create api key with Bearer when first reading it
- Init
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).